### PR TITLE
Improve landing page UX with smart redirects and username preservation

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { startAuthentication } from "@simplewebauthn/browser";
 import { trpc } from "@/lib/trpc";
@@ -17,9 +17,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter();
-  const [username, setUsername] = useState("");
+  const searchParams = useSearchParams();
+  const initialUsername = searchParams.get("username") ?? "";
+
+  const [username, setUsername] = useState(initialUsername);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -62,6 +65,10 @@ export default function LoginPage() {
     }
   }
 
+  const registerHref = username
+    ? `/register?username=${encodeURIComponent(username)}`
+    : "/register";
+
   return (
     <Card>
       <CardHeader>
@@ -93,12 +100,52 @@ export default function LoginPage() {
           </Button>
           <p className="text-sm text-muted-foreground">
             Don&apos;t have an account?{" "}
-            <Link href="/register" className="text-primary hover:underline">
+            <Link href={registerHref} className="text-primary hover:underline">
               Create one
             </Link>
           </p>
         </CardFooter>
       </form>
     </Card>
+  );
+}
+
+function LoginFormFallback() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sign In</CardTitle>
+        <CardDescription>Use your passkey to sign in securely</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="username">Username</Label>
+          <Input
+            id="username"
+            name="username"
+            type="text"
+            placeholder="johndoe"
+            disabled
+          />
+        </div>
+      </CardContent>
+      <CardFooter className="flex flex-col space-y-4">
+        <Button className="w-full" disabled>
+          Sign in with passkey
+        </Button>
+        <p className="text-sm text-muted-foreground">
+          Don&apos;t have an account?{" "}
+          <span className="text-primary">Create one</span>
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={<LoginFormFallback />}>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { startRegistration } from "@simplewebauthn/browser";
 import { trpc } from "@/lib/trpc";
@@ -17,9 +17,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-export default function RegisterPage() {
+function RegisterForm() {
   const router = useRouter();
-  const [username, setUsername] = useState("");
+  const searchParams = useSearchParams();
+  const initialUsername = searchParams.get("username") ?? "";
+
+  const [username, setUsername] = useState(initialUsername);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -69,6 +72,10 @@ export default function RegisterPage() {
     }
   }
 
+  const loginHref = username
+    ? `/login?username=${encodeURIComponent(username)}`
+    : "/login";
+
   return (
     <Card>
       <CardHeader>
@@ -104,12 +111,53 @@ export default function RegisterPage() {
           </Button>
           <p className="text-sm text-muted-foreground">
             Already have an account?{" "}
-            <Link href="/login" className="text-primary hover:underline">
+            <Link href={loginHref} className="text-primary hover:underline">
               Sign in
             </Link>
           </p>
         </CardFooter>
       </form>
     </Card>
+  );
+}
+
+function RegisterFormFallback() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create Account</CardTitle>
+        <CardDescription>
+          Register with a passkey for secure, passwordless authentication
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="username">Username</Label>
+          <Input
+            id="username"
+            name="username"
+            type="text"
+            placeholder="johndoe"
+            disabled
+          />
+        </div>
+      </CardContent>
+      <CardFooter className="flex flex-col space-y-4">
+        <Button className="w-full" disabled>
+          Create passkey
+        </Button>
+        <p className="text-sm text-muted-foreground">
+          Already have an account? <span className="text-primary">Sign in</span>
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}
+
+export default function RegisterPage() {
+  return (
+    <Suspense fallback={<RegisterFormFallback />}>
+      <RegisterForm />
+    </Suspense>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,57 +2,25 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { trpc } from "@/lib/trpc";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 
 export default function HomePage() {
   const router = useRouter();
   const { data: session, isLoading } = trpc.auth.session.useQuery();
 
   useEffect(() => {
-    if (session) {
-      router.push("/profile");
+    if (!isLoading) {
+      if (session) {
+        router.push("/profile");
+      } else {
+        router.push("/login");
+      }
     }
-  }, [session, router]);
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-muted-foreground">Loading...</div>
-      </div>
-    );
-  }
-
-  if (session) {
-    return null; // Redirecting
-  }
+  }, [session, isLoading, router]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle className="text-2xl">FIDO2 Blueprint</CardTitle>
-          <CardDescription>
-            Secure, passwordless authentication with passkeys
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <Button asChild className="w-full">
-            <Link href="/login">Sign In</Link>
-          </Button>
-          <Button asChild variant="outline" className="w-full">
-            <Link href="/register">Create Account</Link>
-          </Button>
-        </CardContent>
-      </Card>
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-muted-foreground">Loading...</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Landing page redirect**: The root URL (`/`) now automatically redirects to `/login` for unauthenticated users or `/profile` for authenticated users, instead of showing a card with two buttons
- **Username preservation**: When navigating between login and register pages, the typed username is passed via query parameter and pre-filled in the target page
- **Suspense boundaries**: Added proper Suspense wrappers for `useSearchParams()` as required by Next.js 14+

## Changes

| File | Change |
|------|--------|
| `src/app/page.tsx` | Simplified to redirect-only logic with loading spinner |
| `src/app/(auth)/login/page.tsx` | Added Suspense boundary, reads `?username=` param, passes username to register link |
| `src/app/(auth)/register/page.tsx` | Added Suspense boundary, reads `?username=` param, passes username to login link |
| `tests/e2e/auth.spec.ts` | Added 3 new E2E tests for redirect behavior and username preservation |

## Testing

- All 8 E2E tests pass (3 new tests added)
- Build and lint pass