### PR TITLE
Add passkey naming feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ next-env.d.ts
 /test-results/
 /playwright-report/
 /playwright/.cache/
+sqlite.db

--- a/drizzle/0000_past_tarantula.sql
+++ b/drizzle/0000_past_tarantula.sql
@@ -1,6 +1,7 @@
 CREATE TABLE `credentials` (
 	`id` text PRIMARY KEY NOT NULL,
 	`user_id` text NOT NULL,
+	`name` text NOT NULL,
 	`public_key` blob NOT NULL,
 	`counter` integer NOT NULL,
 	`device_type` text NOT NULL,

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "fb04adcb-e327-44e4-a2d4-a3a7ab4eaac9",
+  "id": "63c804e1-c4ba-4976-a174-ea8912a3ad33",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "credentials": {
@@ -16,6 +16,13 @@
         },
         "user_id": {
           "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
           "type": "text",
           "primaryKey": false,
           "notNull": true,

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1767702642557,
-      "tag": "0000_powerful_lionheart",
+      "when": 1767724072075,
+      "tag": "0000_past_tarantula",
       "breakpoints": true
     }
   ]

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -14,6 +14,8 @@ export const credentials = sqliteTable("credentials", {
   userId: text("user_id")
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
+  // User-friendly name for the passkey (e.g., "My Phone", "Work Laptop")
+  name: text("name").notNull(),
   // The public key in COSE format
   publicKey: blob("public_key", { mode: "buffer" }).notNull(),
   // Counter for replay attack prevention


### PR DESCRIPTION
## Summary

Add the ability for users to identify and manage their passkeys with custom names.

## Changes

- **Auto-generate passkey names**: When a passkey is registered, it's automatically named "Passkey 1", "Passkey 2", etc.
- **Display names on profile page**: Passkey name is shown as the primary label
- **Rename functionality**: Users can click a pencil icon to rename their passkeys
- **"Consider renaming" badge**: Auto-generated names show a badge prompting the user to give them a meaningful name
- **Database schema**: Added `name` column to credentials table
- **New tRPC procedure**: `renameCredential` for updating passkey names
- **E2E test**: Covers auto-naming and rename flow

## UI Preview

**Before renaming:**
```
🔑 Passkey 1  [Consider renaming]  ✏️  🗑️
   Single-device passkey
   Created: Jan 6, 2026 · Last used: Never
```

**After renaming:**
```
🔑 My Phone  ✏️  🗑️
   Single-device passkey
   Created: Jan 6, 2026 · Last used: Never
```

## Testing

- All 9 E2E tests pass (including new passkey naming test)
- Build and lint pass