### PR TITLE
Add production start script for flexible deployment

### DIFF
--- a/scripts/start-prod.sh
+++ b/scripts/start-prod.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Production start script that reads configuration from environment variables
+# Usage: PORT=3001 HOSTNAME=127.0.0.1 ./scripts/start-prod.sh
+
+NEXT_PORT="${PORT:-3000}"
+NEXT_HOSTNAME="${HOSTNAME:-0.0.0.0}"
+
+exec npx next start --hostname "$NEXT_HOSTNAME" --port "$NEXT_PORT"


### PR DESCRIPTION
## Summary
- Adds `scripts/start-prod.sh` wrapper script for production deployments
- Reads `PORT` and `HOSTNAME` environment variables and passes them as CLI flags to Next.js
- Keeps `package.json` generic while allowing flexible deployment configuration via environment variables