### PR TITLE
Add deployment documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,46 +90,131 @@ This blueprint emphasizes E2E tests because:
 
 Unit tests are still valuable for complex business logic, but the E2E tests are the primary safety net.
 
-## Session Security
-
-Sessions use sliding expiration with an absolute maximum:
-
-- **Idle timeout**: Session expires after inactivity (configurable via `SESSION_IDLE_TIMEOUT_MINUTES`, default 30)
-- **Absolute maximum**: Even active sessions expire (configurable via `SESSION_ABSOLUTE_TIMEOUT_HOURS`, default 8)
-
-Cookie security flags:
-
-- `httpOnly`: Not accessible via JavaScript
-- `secure`: HTTPS only (in production)
-- `sameSite: strict`: Not sent with cross-site requests
-
 ## Multi-Device Support
 
 Users can register multiple passkeys (e.g., phone + laptop + security key). The credential management UI allows adding and removing passkeys, with protection against removing the last one.
 
 Modern passkeys sync across devices automatically (via iCloud Keychain, Google Password Manager, etc.), so most users won't need to manually add multiple credentials.
 
-## WebAuthn Configuration
+## Deployment
 
-The WebAuthn Relying Party is configured via environment variables:
+### Environment Variables
 
-| Variable           | Description  | Example                      |
-| ------------------ | ------------ | ---------------------------- |
-| `WEBAUTHN_RP_ID`   | Domain name  | `localhost` or `example.com` |
-| `WEBAUTHN_RP_NAME` | Display name | `My App`                     |
-| `WEBAUTHN_ORIGIN`  | Full origin  | `https://example.com`        |
+| Variable                         | Required | Default                 | Description                                           |
+| -------------------------------- | -------- | ----------------------- | ----------------------------------------------------- |
+| `SESSION_SECRET`                 | Yes      | -                       | Encryption key for sessions (min 32 chars)            |
+| `WEBAUTHN_RP_ID`                 | Yes      | `localhost`             | Domain name for passkey binding                       |
+| `WEBAUTHN_RP_NAME`               | Yes      | `FIDO2 Blueprint`       | Display name shown during passkey registration        |
+| `WEBAUTHN_ORIGIN`                | Yes      | `http://localhost:3000` | Full origin URL for WebAuthn                          |
+| `DATABASE_PATH`                  | Yes      | `./data/app.db`         | Path to SQLite database file                          |
+| `SESSION_IDLE_TIMEOUT_MINUTES`   | No       | `30`                    | Session expires after this many minutes idle          |
+| `SESSION_ABSOLUTE_TIMEOUT_HOURS` | No       | `8`                     | Maximum session lifetime regardless of activity       |
+| `PORT`                           | No       | `3000`                  | Server port (used by `scripts/start-prod.sh`)         |
+| `HOSTNAME`                       | No       | `0.0.0.0`               | Server bind address (used by `scripts/start-prod.sh`) |
 
-**Important**: `RP_ID` must match your domain. Passkeys are bound to this identifier and won't work if it changes.
+### Production Setup
 
-## Production Considerations
+1. **Create a data directory outside the repo** (safe from `git clean`):
 
-Before deploying:
+   ```bash
+   mkdir /path/to/fido2-data
+   ```
 
-1. **Generate a strong session secret** (32+ random bytes)
-2. **Use HTTPS** (required for WebAuthn in production)
-3. **Set correct RP_ID** (your production domain)
-4. **Consider database** (PostgreSQL for multi-server deployments)
-5. **Set up monitoring** (failed auth attempts, error rates)
+2. **Create `.env.local`**:
+
+   ```bash
+   SESSION_SECRET=$(openssl rand -base64 32)
+   WEBAUTHN_RP_ID=example.com
+   WEBAUTHN_RP_NAME=FIDO2 Blueprint
+   WEBAUTHN_ORIGIN=https://example.com
+   DATABASE_PATH=/path/to/fido2-data/app.db
+   ```
+
+3. **Build and run migrations**:
+
+   ```bash
+   pnpm install
+   pnpm build
+   DATABASE_PATH=/path/to/fido2-data/app.db pnpm db:migrate
+   ```
+
+4. **Start the server** using the production script:
+   ```bash
+   PORT=3001 HOSTNAME=127.0.0.1 ./scripts/start-prod.sh
+   ```
+
+### systemd Service Example
+
+```ini
+[Unit]
+Description=FIDO2 Blueprint
+After=network.target
+
+[Service]
+Type=simple
+User=youruser
+WorkingDirectory=/path/to/fido2-blueprint
+ExecStart=/path/to/fido2-blueprint/scripts/start-prod.sh
+Restart=on-failure
+RestartSec=5
+Environment=NODE_ENV=production
+Environment=PORT=3001
+Environment=HOSTNAME=127.0.0.1
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Place this in `/etc/systemd/system/fido2-blueprint.service`, then:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now fido2-blueprint
+```
+
+### Reverse Proxy
+
+The server binds to localhost only (`HOSTNAME=127.0.0.1`). Use a reverse proxy like Caddy or nginx to handle HTTPS:
+
+**Caddy example** (`/etc/caddy/Caddyfile`):
+
+```
+fido2.example.com {
+    reverse_proxy localhost:3001
+}
+```
+
+Caddy automatically provisions SSL certificates via Let's Encrypt.
+
+### Development Workflow on a Server
+
+When developing on a deployed server (e.g., testing passkeys on a mobile device), you have two options:
+
+**Option 1: Rebuild and restart** (production mode)
+
+```bash
+pnpm build
+sudo systemctl restart fido2-blueprint
+```
+
+**Option 2: Dev mode with hot reload** (faster iteration)
+
+```bash
+sudo systemctl stop fido2-blueprint
+PORT=3001 pnpm dev
+# Ctrl+C when done, then restart production:
+sudo systemctl start fido2-blueprint
+```
+
+Dev mode provides instant hot reload on code changes. Note that `pnpm dev` binds to all interfaces by default, which is acceptable for short dev sessions.
+
+### Production Checklist
+
+- Generate a strong session secret (32+ random bytes)
+- Use HTTPS (required for WebAuthn)
+- Set correct `WEBAUTHN_RP_ID` (passkeys are bound to this domain)
+- Store database outside the repo
+- Back up the database regularly
 
 ## License
 


### PR DESCRIPTION
## Summary
- Documents all environment variables with defaults and descriptions
- Adds step-by-step production setup guide
- Includes systemd service example
- Includes Caddy reverse proxy example
- Documents development workflow on a deployed server (rebuild vs dev mode)
- Adds production checklist