### PR TITLE
Security: Bind challenge to userId/username in session cookie

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -78,14 +78,13 @@ function LoginForm() {
 
     try {
       // Step 1: Get authentication options from server
-      const { options, userId } = await loginStart.mutateAsync({ username });
+      const { options } = await loginStart.mutateAsync({ username });
 
       // Step 2: Authenticate with passkey
       const credential = await startAuthentication({ optionsJSON: options });
 
-      // Step 3: Verify with server
+      // Step 3: Verify with server (userId comes from session cookie, not client)
       await loginFinish.mutateAsync({
-        userId,
         credential,
       });
 
@@ -117,19 +116,13 @@ function LoginForm() {
 
     try {
       // Step 1: Get registration options from server
-      const {
-        options,
-        userId,
-        username: normalizedUsername,
-      } = await registerStart.mutateAsync({ username });
+      const { options } = await registerStart.mutateAsync({ username });
 
       // Step 2: Create credential with authenticator
       const credential = await startRegistration({ optionsJSON: options });
 
-      // Step 3: Verify with server and create account
+      // Step 3: Verify with server and create account (userId/username come from session cookie)
       await registerFinish.mutateAsync({
-        userId,
-        username: normalizedUsername,
         credential,
       });
 


### PR DESCRIPTION
## Summary

Security fix that cryptographically binds the WebAuthn challenge to the userId and username in the session cookie.

## Problem

Previously, `registerFinish` and `loginFinish` accepted `userId` and `username` from the client request. These values were not bound to the challenge stored in the session cookie. An attacker who stole a victim's cookie (via XSS, network attack, etc.) could potentially:

1. Use the victim's challenge with their own userId/username
2. Register the victim's passkey to a different account

## Solution

- Store `pendingUserId` and `pendingUsername` in the encrypted session cookie during `*Start` endpoints
- Retrieve these values from the cookie in `*Finish` endpoints (not from client request)
- Remove `userId`/`username` from `registerFinish` and `loginFinish` input schemas
- Client no longer sends these fields (breaking API change, but internal only)

## Changes

- `src/server/auth/session.ts` - Add `pendingUserId`/`pendingUsername` to session, update `storeChallenge` and `getAndClearChallenge`
- `src/server/trpc/routers/auth.ts` - Update register/login endpoints to use cookie data
- `src/server/trpc/routers/profile.ts` - Update `addPasskeyStart`/`addPasskeyFinish` with defense-in-depth check
- `src/app/(auth)/login/page.tsx` - Stop sending userId/username in finish calls