### PR TITLE
Display transports info in profile page

### DIFF
--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -305,6 +305,12 @@ export default function ProfilePage() {
                         Created: {formatDate(cred.createdAt)} · Last used:{" "}
                         {formatDate(cred.lastUsedAt)}
                       </p>
+                      {cred.transports && (
+                        <p className="text-sm text-muted-foreground">
+                          Transports:{" "}
+                          {(JSON.parse(cred.transports) as string[]).join(", ")}
+                        </p>
+                      )}
                     </div>
                   </div>
                   <Button

--- a/src/server/auth/fido2.ts
+++ b/src/server/auth/fido2.ts
@@ -195,6 +195,7 @@ export async function getUserCredentials(userId: string) {
       name: schema.credentials.name,
       deviceType: schema.credentials.deviceType,
       backedUp: schema.credentials.backedUp,
+      transports: schema.credentials.transports,
       createdAt: schema.credentials.createdAt,
       lastUsedAt: schema.credentials.lastUsedAt,
     })

--- a/src/server/trpc/routers/profile.ts
+++ b/src/server/trpc/routers/profile.ts
@@ -66,6 +66,7 @@ export const profileRouter = router({
       name: cred.name,
       deviceType: cred.deviceType,
       backedUp: cred.backedUp,
+      transports: cred.transports,
       createdAt: cred.createdAt,
       lastUsedAt: cred.lastUsedAt,
     }));


### PR DESCRIPTION
## Summary

Show the transports (usb, nfc, internal, etc.) for each passkey on the profile page. This is de-emphasized information primarily useful for developers.

## Changes

- `src/server/auth/fido2.ts` - Add `transports` to `getUserCredentials()` select query
- `src/server/trpc/routers/profile.ts` - Include `transports` in the mapped credentials result
- `src/app/(app)/profile/page.tsx` - Display transports as a small gray line below each passkey

## Display Example

```
My YubiKey                                    [🗑️]
Multi-device passkey (synced)
Created: Jan 15, 2026 · Last used: Jan 16, 2026
Transports: usb, nfc
```