### PR TITLE
Add paranoid error logging for debugging intermittent failures

### DIFF
--- a/src/lib/error-utils.ts
+++ b/src/lib/error-utils.ts
@@ -1,0 +1,48 @@
+import { TRPCClientError } from "@trpc/client";
+
+export function getErrorMessage(err: unknown): string {
+  if (err instanceof TRPCClientError) {
+    const zodError = err.data?.zodError;
+    if (zodError?.fieldErrors) {
+      const firstField = Object.keys(zodError.fieldErrors)[0];
+      if (firstField && zodError.fieldErrors[firstField]?.[0]) {
+        return zodError.fieldErrors[firstField][0];
+      }
+    }
+    return (
+      err.message ||
+      `TRPCClientError (no message, code: ${err.data?.code ?? "unknown"})`
+    );
+  }
+  if (err instanceof Error) {
+    return err.message || `${err.name || "Error"} (no message)`;
+  }
+  return `Unknown error: ${JSON.stringify(err)}`;
+}
+
+export function getWebAuthnErrorMessage(
+  err: unknown,
+  context: "login" | "register"
+): string {
+  if (err instanceof Error) {
+    const errorDetail = `[${err.name}] ${err.message || "(no message)"}`;
+
+    switch (err.name) {
+      case "NotAllowedError":
+        return context === "login"
+          ? `Authentication was cancelled or timed out (${errorDetail})`
+          : `Passkey creation was cancelled or timed out (${errorDetail})`;
+      case "InvalidStateError":
+        return `This passkey is already registered (${errorDetail})`;
+      case "AbortError":
+        return context === "login"
+          ? `Authentication was aborted (${errorDetail})`
+          : `Passkey creation was aborted (${errorDetail})`;
+      case "SecurityError":
+        return `Security error (${errorDetail})`;
+      default:
+        return getErrorMessage(err);
+    }
+  }
+  return getErrorMessage(err);
+}


### PR DESCRIPTION
## Summary

Add comprehensive error logging and display to help debug intermittent login failures where the authenticator prompt disappears but no error is shown.

## Problem

On rare occasions, login with a passkey fails silently - the user stays on the login page with no error message. This makes debugging very difficult.

## Solution

### 1. New shared error utilities (`src/lib/error-utils.ts`)

- `getErrorMessage()` - extracts message from any error, never returns empty string
- `getWebAuthnErrorMessage()` - handles WebAuthn-specific errors with context

### 2. Verbose console logging

Every step of login, register, and add passkey flows now logs:
```
[Login] Step 1: Calling loginStart...
[Login] Step 1 complete: Got options
[Login] Step 2: Calling startAuthentication...
[Login] Step 2 complete: Got credential
[Login] Step 3: Calling loginFinish...
[Login] Step 3 complete: Verified
[Login] Success, redirecting...
```

On error:
```
[Login] Error caught: <full error object>
```

### 3. Detailed error display

- Shows error name and message: `[NotAllowedError] The operation either timed out or was not allowed`
- Handles more WebAuthn error types: `AbortError`, `SecurityError`
- Never shows empty error (fallback to descriptive text)

### 4. "Copy error details" button

Users can click to copy the error message to clipboard, with "Copied!" feedback.

## Files Changed

- `src/lib/error-utils.ts` - **New file** with shared error handling
- `src/app/(auth)/login/page.tsx` - Use shared utils, add logging, add copy button
- `src/app/(app)/profile/page.tsx` - Same treatment for `handleAddPasskey()`