### PR TITLE
Fix login redirect race condition by invalidating session cache

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -10,6 +10,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!isLoading && !session) {
+      console.log("[AppLayout] No session, redirecting to login");
       router.push("/login");
     }
   }, [session, isLoading, router]);

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -52,6 +52,7 @@ function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const initialUsername = searchParams.get("username") ?? "";
+  const utils = trpc.useUtils();
 
   const [username, setUsername] = useState(initialUsername);
   const [error, setError] = useState<string | null>(null);
@@ -87,6 +88,10 @@ function LoginForm() {
       await loginFinish.mutateAsync({
         credential,
       });
+
+      // Invalidate session cache before redirect to prevent race condition
+      // where profile layout sees stale "no session" and redirects back to login
+      await utils.auth.session.invalidate();
 
       // Success - redirect to profile
       router.push("/profile");
@@ -125,6 +130,10 @@ function LoginForm() {
       await registerFinish.mutateAsync({
         credential,
       });
+
+      // Invalidate session cache before redirect to prevent race condition
+      // where profile layout sees stale "no session" and redirects back to login
+      await utils.auth.session.invalidate();
 
       // Success - redirect to profile
       router.push("/profile");


### PR DESCRIPTION
## Summary

- Invalidate tRPC session cache before `router.push("/profile")` in both login and registration flows
- Fixes intermittent issue where successful login would redirect back to login page with no error

## Problem

After successful authentication, there was a race condition:
1. Login completes, sets session cookie
2. `router.push("/profile")` triggers navigation
3. Profile layout's `trpc.auth.session.useQuery()` returns **cached** stale "no session" response
4. Layout redirects back to `/login`

## Solution

Call `await utils.auth.session.invalidate()` before the redirect. This clears the tRPC query cache, ensuring the profile layout fetches fresh session data.

Also added a debug log in `AppLayout` when redirecting to login, to help diagnose any future session issues.