### PR TITLE
Fix login page: reduce spacing, change 'your passkey' to 'a passkey'

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -152,7 +152,7 @@ function LoginForm() {
         <CardHeader>
           <CardTitle>Create Account</CardTitle>
           <CardDescription>
-            Choose a username and create your passkey
+            Choose a username and create a passkey
           </CardDescription>
         </CardHeader>
         <form onSubmit={handleRegister} noValidate>
@@ -201,11 +201,13 @@ function LoginForm() {
     <Card>
       <CardHeader>
         <CardTitle>Sign In</CardTitle>
-        <CardDescription>Use your passkey to sign in securely</CardDescription>
+        <CardDescription>Use a passkey to sign in securely</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4">
-        {error && <div className="text-sm text-destructive">{error}</div>}
-      </CardContent>
+      {error && (
+        <CardContent>
+          <div className="text-sm text-destructive">{error}</div>
+        </CardContent>
+      )}
       <CardFooter className="flex flex-col space-y-4">
         <Button onClick={handleLogin} className="w-full" disabled={isDisabled}>
           {isLoading ? "Authenticating..." : "Sign in with passkey"}
@@ -234,9 +236,8 @@ function LoginFormFallback() {
     <Card>
       <CardHeader>
         <CardTitle>Sign In</CardTitle>
-        <CardDescription>Use your passkey to sign in securely</CardDescription>
+        <CardDescription>Use a passkey to sign in securely</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4" />
       <CardFooter className="flex flex-col space-y-4">
         <Button className="w-full" disabled>
           Sign in with passkey


### PR DESCRIPTION
## Changes

- Remove empty `CardContent` on login view - only render when there's an error to display (fixes excessive vertical spacing)
- Change "your passkey" to "a passkey" in descriptions (implies multiple passkeys are possible)

Affects login view, registration view, and loading fallback.