### PR TITLE
Add vertical spacing between username field and button on registration

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -172,7 +172,7 @@ function LoginForm() {
             </div>
             {error && <div className="text-sm text-destructive">{error}</div>}
           </CardContent>
-          <CardFooter className="flex flex-col space-y-4">
+          <CardFooter className="flex flex-col space-y-4 pt-6">
             <Button type="submit" className="w-full" disabled={isDisabled}>
               {isRegistering ? "Creating account..." : "Create account"}
             </Button>


### PR DESCRIPTION
Adds `pt-6` to CardFooter in registration form to create consistent vertical spacing between the username input and the Create account button.