### PR TITLE
Document vitest coverage config (commented out)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/unit/**/*.test.ts"],
+    // Coverage requires @vitest/coverage-v8 which is not installed.
+    // Knip reports unlisted dependencies, so we comment this out.
+    // To enable: pnpm add -D @vitest/coverage-v8
+    // Then uncomment below and run: pnpm test --coverage
+    // coverage: {
+    //   provider: "v8",
+    //   reporter: ["text", "json", "html"],
+    // },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Restores the coverage configuration as comments with instructions for enabling.

This preserves the knowledge of the recommended v8 coverage setup while avoiding the unlisted dependency warning from knip.

```typescript
// Coverage requires @vitest/coverage-v8 which is not installed.
// Knip reports unlisted dependencies, so we comment this out.
// To enable: pnpm add -D @vitest/coverage-v8
// Then uncomment below and run: pnpm test --coverage
// coverage: {
//   provider: "v8",
//   reporter: ["text", "json", "html"],
// },
```