### PR TITLE
Fix db:migrate to load .env.local

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "tsx src/server/db/migrate.ts",
+    "db:migrate": "tsx --env-file=.env.local src/server/db/migrate.ts",
     "db:studio": "drizzle-kit studio",
     "test": "vitest",
     "test:e2e": "playwright test",


### PR DESCRIPTION
Uses `tsx --env-file` flag to ensure `DATABASE_PATH` is loaded from `.env.local`.

Previously, the migrate script used the default path `./data/app.db` instead of the configured path in `.env.local`, causing migrations to run against the wrong database file.