### PR TITLE
Replace deprecated React.FormEvent with React.SubmitEvent

### DIFF
--- a/apps/fido2-web-demo/src/app/(app)/profile/page.tsx
+++ b/apps/fido2-web-demo/src/app/(app)/profile/page.tsx
@@ -55,7 +55,7 @@ export default function ProfilePage() {
   >(null);
   const [newCredentialName, setNewCredentialName] = useState("");
 
-  async function handleUpdateDisplayName(e: React.FormEvent) {
+  async function handleUpdateDisplayName(e: React.SubmitEvent) {
     e.preventDefault();
     try {
       await updateDisplayName.mutateAsync({ displayName });

--- a/apps/fido2-web-demo/src/app/(auth)/register/page.tsx
+++ b/apps/fido2-web-demo/src/app/(auth)/register/page.tsx
@@ -39,7 +39,7 @@ function RegisterCard({
   onUsernameChange?: (value: string) => void;
   error?: string | null;
   isRegistering?: boolean;
-  onSubmit?: (e: React.FormEvent) => void;
+  onSubmit?: (e: React.SubmitEvent) => void;
 }) {
   const disabled = isRegistering || !onSubmit;
 
@@ -99,7 +99,7 @@ function RegisterForm() {
   const registerStart = trpc.auth.registerStart.useMutation();
   const registerFinish = trpc.auth.registerFinish.useMutation();
 
-  async function handleRegister(e: React.FormEvent) {
+  async function handleRegister(e: React.SubmitEvent) {
     e.preventDefault();
     setError(null);
 


### PR DESCRIPTION
## Summary
- Updates form submit handlers to use `React.SubmitEvent` instead of the deprecated `React.FormEvent`
- Affects `profile/page.tsx` and `register/page.tsx`
- No functional changes, just type improvements following React 19 best practices