### PR TITLE
Rename AuthError to ServerAuthError and add BrowserAuthError

### DIFF
--- a/apps/fido2-web-demo/src/app/(app)/profile/page.tsx
+++ b/apps/fido2-web-demo/src/app/(app)/profile/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { startRegistration } from "@simplewebauthn/browser";
 import { trpc } from "@/lib/trpc";
-import { toBrowserAuthError } from "@/lib/errors";
+import { getBrowserAuthErrorCode } from "@/lib/errors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -77,9 +77,9 @@ export default function ProfilePage() {
       });
       await addPasskeyFinish.mutateAsync({ authenticatorResponse });
     } catch (err) {
-      const browserAuthError = toBrowserAuthError(err);
-      if (browserAuthError) {
-        switch (browserAuthError.code) {
+      const errorCode = getBrowserAuthErrorCode(err);
+      if (errorCode) {
+        switch (errorCode) {
           case "CANCELLED_OR_DENIED":
             setError("Cancelled or timed out");
             break;

--- a/apps/fido2-web-demo/src/app/(auth)/login/page.tsx
+++ b/apps/fido2-web-demo/src/app/(auth)/login/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 import { startAuthentication } from "@simplewebauthn/browser";
 import { trpc } from "@/lib/trpc";
-import { getErrorMessage, toBrowserAuthError } from "@/lib/errors";
+import { getErrorMessage, getBrowserAuthErrorCode } from "@/lib/errors";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -90,8 +90,8 @@ function LoginForm() {
       // Success - redirect to profile
       router.push("/profile");
     } catch (err) {
-      const browserAuthError = toBrowserAuthError(err);
-      if (browserAuthError) {
+      const errorCode = getBrowserAuthErrorCode(err);
+      if (errorCode) {
         // Login only sees CANCELLED_OR_DENIED (no ALREADY_REGISTERED possible)
         setError("Cancelled or timed out");
         return;

--- a/apps/fido2-web-demo/src/app/(auth)/login/page.tsx
+++ b/apps/fido2-web-demo/src/app/(auth)/login/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 import { startAuthentication } from "@simplewebauthn/browser";
 import { trpc } from "@/lib/trpc";
-import { getErrorMessage } from "@/lib/errors";
+import { getErrorMessage, toBrowserAuthError } from "@/lib/errors";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -90,12 +90,13 @@ function LoginForm() {
       // Success - redirect to profile
       router.push("/profile");
     } catch (err) {
-      // Handle WebAuthn errors specially
-      if (err instanceof Error && err.name === "NotAllowedError") {
-        setError("Authentication was cancelled or timed out");
-      } else {
-        setError(getErrorMessage(err));
+      const browserAuthError = toBrowserAuthError(err);
+      if (browserAuthError) {
+        // Login only sees CANCELLED_OR_DENIED (no ALREADY_REGISTERED possible)
+        setError("Cancelled or timed out");
+        return;
       }
+      setError(getErrorMessage(err));
     } finally {
       setIsLoading(false);
     }

--- a/apps/fido2-web-demo/src/app/(auth)/register/page.tsx
+++ b/apps/fido2-web-demo/src/app/(auth)/register/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 import { startRegistration } from "@simplewebauthn/browser";
 import { trpc } from "@/lib/trpc";
-import { getErrorMessage, toBrowserAuthError } from "@/lib/errors";
+import { getErrorMessage, getBrowserAuthErrorCode } from "@/lib/errors";
 import { usernameSchema } from "@repo/fido2-auth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -132,9 +132,9 @@ function RegisterForm() {
       // Success - redirect to profile
       router.push("/profile");
     } catch (err) {
-      const browserAuthError = toBrowserAuthError(err);
-      if (browserAuthError) {
-        switch (browserAuthError.code) {
+      const errorCode = getBrowserAuthErrorCode(err);
+      if (errorCode) {
+        switch (errorCode) {
           case "CANCELLED_OR_DENIED":
             setError("Cancelled or timed out");
             break;

--- a/apps/fido2-web-demo/src/lib/errors.ts
+++ b/apps/fido2-web-demo/src/lib/errors.ts
@@ -1,5 +1,33 @@
 import { TRPCClientError } from "@trpc/client";
 
+// Browser-side authentication errors (from WebAuthn API)
+export type BrowserAuthErrorCode =
+  | "CANCELLED_OR_DENIED" // NotAllowedError - user cancelled, timed out, or blocked
+  | "ALREADY_REGISTERED"; // InvalidStateError - credential already exists
+
+export class BrowserAuthError extends Error {
+  constructor(
+    public readonly code: BrowserAuthErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "BrowserAuthError";
+  }
+}
+
+// Convert browser WebAuthn errors to BrowserAuthError
+export function toBrowserAuthError(err: unknown): BrowserAuthError | null {
+  if (err instanceof Error) {
+    if (err.name === "NotAllowedError") {
+      return new BrowserAuthError("CANCELLED_OR_DENIED", err.message);
+    }
+    if (err.name === "InvalidStateError") {
+      return new BrowserAuthError("ALREADY_REGISTERED", err.message);
+    }
+  }
+  return null;
+}
+
 export function getErrorMessage(err: unknown): string {
   if (err instanceof TRPCClientError) {
     // Check for Zod validation errors (properly formatted by server)

--- a/apps/fido2-web-demo/src/lib/errors.ts
+++ b/apps/fido2-web-demo/src/lib/errors.ts
@@ -5,25 +5,13 @@ export type BrowserAuthErrorCode =
   | "CANCELLED_OR_DENIED" // NotAllowedError - user cancelled, timed out, or blocked
   | "ALREADY_REGISTERED"; // InvalidStateError - credential already exists
 
-export class BrowserAuthError extends Error {
-  constructor(
-    public readonly code: BrowserAuthErrorCode,
-    message: string
-  ) {
-    super(message);
-    this.name = "BrowserAuthError";
-  }
-}
-
-// Convert browser WebAuthn errors to BrowserAuthError
-export function toBrowserAuthError(err: unknown): BrowserAuthError | null {
+// Convert browser WebAuthn errors to a typed error code
+export function getBrowserAuthErrorCode(
+  err: unknown
+): BrowserAuthErrorCode | null {
   if (err instanceof Error) {
-    if (err.name === "NotAllowedError") {
-      return new BrowserAuthError("CANCELLED_OR_DENIED", err.message);
-    }
-    if (err.name === "InvalidStateError") {
-      return new BrowserAuthError("ALREADY_REGISTERED", err.message);
-    }
+    if (err.name === "NotAllowedError") return "CANCELLED_OR_DENIED";
+    if (err.name === "InvalidStateError") return "ALREADY_REGISTERED";
   }
   return null;
 }

--- a/apps/fido2-web-demo/src/server/trpc/routers/auth.ts
+++ b/apps/fido2-web-demo/src/server/trpc/routers/auth.ts
@@ -10,7 +10,7 @@ import {
   getAndClearChallengeUsernameless,
 } from "@/server/auth/session";
 import { auth } from "@/server/auth";
-import { AuthError, usernameSchema } from "@repo/fido2-auth";
+import { ServerAuthError, usernameSchema } from "@repo/fido2-auth";
 
 export const authRouter = router({
   // Get current session
@@ -37,7 +37,10 @@ export const authRouter = router({
 
         return { options };
       } catch (error) {
-        if (error instanceof AuthError && error.code === "USERNAME_TAKEN") {
+        if (
+          error instanceof ServerAuthError &&
+          error.code === "USERNAME_TAKEN"
+        ) {
           throw new TRPCError({ code: "CONFLICT", message: error.message });
         }
         throw error;
@@ -71,7 +74,7 @@ export const authRouter = router({
         await createSession(userId, username);
         return { success: true };
       } catch (error) {
-        if (error instanceof AuthError) {
+        if (error instanceof ServerAuthError) {
           throw new TRPCError({
             code: error.code === "USERNAME_TAKEN" ? "CONFLICT" : "BAD_REQUEST",
             message: error.message,
@@ -115,7 +118,7 @@ export const authRouter = router({
         await createSession(userId, username);
         return { success: true };
       } catch (error) {
-        if (error instanceof AuthError) {
+        if (error instanceof ServerAuthError) {
           throw new TRPCError({
             code: "UNAUTHORIZED",
             message: error.message,

--- a/apps/fido2-web-demo/src/server/trpc/routers/profile.ts
+++ b/apps/fido2-web-demo/src/server/trpc/routers/profile.ts
@@ -3,7 +3,7 @@ import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../trpc";
 import { storeChallenge, getAndClearChallenge } from "@/server/auth/session";
 import { auth } from "@/server/auth";
-import { AuthError } from "@repo/fido2-auth";
+import { ServerAuthError } from "@repo/fido2-auth";
 
 export const profileRouter = router({
   // Get current user's profile
@@ -11,7 +11,7 @@ export const profileRouter = router({
     try {
       return await auth.getUser(ctx.user.userId);
     } catch (error) {
-      if (error instanceof AuthError && error.code === "USER_NOT_FOUND") {
+      if (error instanceof ServerAuthError && error.code === "USER_NOT_FOUND") {
         throw new TRPCError({ code: "NOT_FOUND", message: error.message });
       }
       throw error;
@@ -98,7 +98,7 @@ export const profileRouter = router({
           input.authenticatorResponse
         );
       } catch (error) {
-        if (error instanceof AuthError) {
+        if (error instanceof ServerAuthError) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: error.message,
@@ -117,7 +117,7 @@ export const profileRouter = router({
       try {
         await auth.removeCredential(ctx.user.userId, input.credentialId);
       } catch (error) {
-        if (error instanceof AuthError) {
+        if (error instanceof ServerAuthError) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: error.message,
@@ -145,7 +145,7 @@ export const profileRouter = router({
           input.name
         );
       } catch (error) {
-        if (error instanceof AuthError) {
+        if (error instanceof ServerAuthError) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: error.message,

--- a/packages/fido2-auth/src/errors.ts
+++ b/packages/fido2-auth/src/errors.ts
@@ -1,4 +1,4 @@
-export type AuthErrorCode =
+export type ServerAuthErrorCode =
   | "USERNAME_TAKEN"
   | "USER_NOT_FOUND"
   | "CREDENTIAL_NOT_FOUND"
@@ -7,12 +7,12 @@ export type AuthErrorCode =
   | "REGISTRATION_FAILED"
   | "AUTHENTICATION_FAILED";
 
-export class AuthError extends Error {
+export class ServerAuthError extends Error {
   constructor(
-    public readonly code: AuthErrorCode,
+    public readonly code: ServerAuthErrorCode,
     message: string
   ) {
     super(message);
-    this.name = "AuthError";
+    this.name = "ServerAuthError";
   }
 }

--- a/packages/fido2-auth/src/index.ts
+++ b/packages/fido2-auth/src/index.ts
@@ -1,4 +1,4 @@
 // Client-safe exports (no Node.js dependencies)
 export { usernameSchema } from "./validation";
-export { AuthError, type AuthErrorCode } from "./errors";
+export { ServerAuthError, type ServerAuthErrorCode } from "./errors";
 export type { WebAuthnConfig } from "./fido2";


### PR DESCRIPTION
## Summary

Improves error handling by clearly separating server-side and browser-side authentication errors:

- **ServerAuthError** (in `@repo/fido2-auth`): Errors from the auth service on the server (username taken, user not found, etc.)
- **BrowserAuthError** (in web demo): Errors from the browser's WebAuthn API (user cancelled, passkey already registered)

This separation clarifies which world each error type lives in, which is important if the auth package is later wrapped behind a JSON/HTTP API and called from different technology stacks.

## Changes

### `@repo/fido2-auth` package
- Rename `AuthError` to `ServerAuthError`
- Rename `AuthErrorCode` to `ServerAuthErrorCode`

### Web demo
- Add `BrowserAuthError` class with codes: `CANCELLED_OR_DENIED`, `ALREADY_REGISTERED`
- Add `toBrowserAuthError()` utility to convert WebAuthn errors
- Update all UI error handling to use the new utility
- Standardize error message to "Cancelled or timed out" across all pages