### PR TITLE
Add comments clarifying error sources in auth pages

### DIFF
--- a/apps/fido2-web-demo/src/app/(app)/profile/page.tsx
+++ b/apps/fido2-web-demo/src/app/(app)/profile/page.tsx
@@ -76,13 +76,19 @@ export default function ProfilePage() {
       });
       await addPasskeyFinish.mutateAsync({ authenticatorResponse });
     } catch (err) {
+      // Errors from the browser's WebAuthn API (authenticator interaction)
       if (err instanceof Error) {
-        if (err.name === "NotAllowedError") {
-          setError("Passkey creation was cancelled");
-        } else {
-          setError(err.message);
+        switch (err.name) {
+          case "NotAllowedError":
+            setError("Passkey creation was cancelled or timed out");
+            return;
+          case "InvalidStateError":
+            setError("This passkey is already registered");
+            return;
         }
       }
+      // Errors from the server (tRPC/auth package)
+      setError(err instanceof Error ? err.message : "Failed to add passkey");
     } finally {
       setIsAddingPasskey(false);
     }

--- a/apps/fido2-web-demo/src/app/(auth)/login/page.tsx
+++ b/apps/fido2-web-demo/src/app/(auth)/login/page.tsx
@@ -90,12 +90,16 @@ function LoginForm() {
       // Success - redirect to profile
       router.push("/profile");
     } catch (err) {
-      // Handle WebAuthn errors specially
-      if (err instanceof Error && err.name === "NotAllowedError") {
-        setError("Authentication was cancelled or timed out");
-      } else {
-        setError(getErrorMessage(err));
+      // Errors from the browser's WebAuthn API (authenticator interaction)
+      if (err instanceof Error) {
+        switch (err.name) {
+          case "NotAllowedError":
+            setError("Authentication was cancelled or timed out");
+            return;
+        }
       }
+      // Errors from the server (tRPC/auth package)
+      setError(getErrorMessage(err));
     } finally {
       setIsLoading(false);
     }

--- a/apps/fido2-web-demo/src/app/(auth)/register/page.tsx
+++ b/apps/fido2-web-demo/src/app/(auth)/register/page.tsx
@@ -132,16 +132,18 @@ function RegisterForm() {
       // Success - redirect to profile
       router.push("/profile");
     } catch (err) {
-      // Handle WebAuthn errors specially
+      // Errors from the browser's WebAuthn API (authenticator interaction)
       if (err instanceof Error) {
-        if (err.name === "NotAllowedError") {
-          setError("Passkey creation was cancelled or timed out");
-          return;
-        } else if (err.name === "InvalidStateError") {
-          setError("This passkey is already registered");
-          return;
+        switch (err.name) {
+          case "NotAllowedError":
+            setError("Passkey creation was cancelled or timed out");
+            return;
+          case "InvalidStateError":
+            setError("This passkey is already registered");
+            return;
         }
       }
+      // Errors from the server (tRPC/auth package)
       setError(getErrorMessage(err));
     } finally {
       setIsRegistering(false);


### PR DESCRIPTION
## Summary

Adds clarifying comments to error handling code in register, login, and profile pages:

- Documents that `NotAllowedError` and `InvalidStateError` come from the browser's WebAuthn API (authenticator interaction)
- Documents that other errors come from the server (tRPC/auth package)

## Additional fixes

- Adds missing `InvalidStateError` handling to profile page (when adding a passkey with an authenticator that already has one registered)
- Standardizes error message to include "or timed out" on profile page for consistency